### PR TITLE
show: Replace hyphen with non-breaking hyphen

### DIFF
--- a/lib/screens/show.dart
+++ b/lib/screens/show.dart
@@ -98,13 +98,19 @@ class ShowUrlScreen extends StatelessWidget {
                             ),
                             SizedBox(height: 15.h),
                             SelectableLinkify(
-                              text: url,
+                              // XXX: We replace the '-' for non-breaking hyphen
+                              // as hack to avoid the text to be wrapped at '-'
+                              // because we couldn't find a more elegant way to
+                              // do char-by-char wrapping in Flutter.
+                              // This should eventually be
+                              // TextAlign.justify too.
+                              text: url.replaceAll('-', '\u2011'),
                               options: LinkifyOptions(
                                 humanize: false,
                                 defaultToHttps: true,
                                 excludeLastPeriod: false,
                               ),
-                              onOpen: (link) => _launchUrl(link.url, context),
+                              onOpen: (link) => _launchUrl(url, context),
                             ),
                           ],
                         ),


### PR DESCRIPTION
So far there was no way found to make Flutter wrap text on a char-by-char basis
instead of a word-by-word basis, and the regular hyphen (-) is a breaking
character, so wrapping can look very bad as URLs normally consist of only a few
very long *words*.
