### PR TITLE
Make use of rate limit headers

### DIFF
--- a/lib/net.dart
+++ b/lib/net.dart
@@ -2,12 +2,106 @@ import 'dart:convert' show jsonEncode, jsonDecode;
 import 'package:meta/meta.dart' show required;
 import 'package:http/http.dart' as http;
 
+/// Information about current rate limits.
+class RateLimitInfo {
+  /// The maximum number of request that can be done for a period of time.
+  ///
+  /// The period of time is unknown but it ends in [reset] time.
+  final int limit;
+
+  /// The remaining number of requests available until they are [reset].
+  final int remaining;
+
+  /// The remaining time until the limits are reset.
+  final Duration reset;
+
+  /// Creates a [RateLimitInfo].
+  ///
+  /// All arguments should be non-null.
+  const RateLimitInfo({
+    @required this.limit,
+    @required this.remaining,
+    @required this.reset,
+  })  : assert(limit != null),
+        assert(remaining != null),
+        assert(reset != null);
+
+  @override
+  String toString() => '$runtimeType(limit: $limit, remaining: $remaining, '
+      'reset: $reset)';
+}
+
+/// A progressive builder for [RateLimitInfo].
+///
+/// This is a mutable version of [RateLimitInfo], to make it easier to build it
+/// progressively, as [RateLimitInfo] can only be created when we have all the
+/// information and we know it is valid.
+///
+/// After assigning all values, just call [finish] to get the valid
+/// [RateLimitInfo] or null if it's invalid.
+class _RateLimitInfoBuilder {
+  int limit;
+  int remaining;
+  Duration reset;
+  _RateLimitInfoBuilder({
+    this.limit,
+    this.remaining,
+    this.reset,
+  });
+
+  /// Returns the built [RateLimitInfo].
+  ///
+  /// If any field is missing, then it returns null.
+  RateLimitInfo finish() => limit != null && remaining != null && reset != null
+      ? RateLimitInfo(limit: limit, remaining: remaining, reset: reset)
+      : null;
+}
+
+/// A response to a create URL request.
+class CreateUrlResponse {
+  /// The created URL.
+  ///
+  /// Can be null if [error] is non-null.
+  final String url;
+
+  /// An error trying to create the URL.
+  ///
+  /// Is null if there was no error creating the URL.
+  final String error;
+
+  /// Rate limit information associated with the response.
+  ///
+  /// Can be null if there was no rate limit information.
+  final RateLimitInfo rateLimit;
+
+  /// Creates a successful [CreateUrlResponse].
+  ///
+  /// [url] can't be null and [error] will be set to null.
+  const CreateUrlResponse({@required this.url, this.rateLimit})
+      : assert(url != null),
+        error = null;
+
+  /// Creates an failed [CreateUrlResponse].
+  ///
+  /// [error] can't be null and [url] will be set to null.
+  const CreateUrlResponse.error(this.error, {this.rateLimit})
+      : assert(error != null),
+        url = null;
+}
+
 class NoClickService {
   static const SERVER_URL_DEFAULT = 'https://api.noclick.me';
   static const SERVER_URL_VAR_NAME = 'API_URL';
   static const MOCK_RESPONSE_VAR_NAME = 'TEST_API_MOCK_RESPONSE';
-  static const MOCK_RESPONSE =
-      'https://noclick.me/_test/Lorem_ipsum_dolor_sit_amet-_consectetur_adipiscing_elit._Ut_odio_felis-_maximus_eget_ex_nec-_varius_efficitur_lorem._Donec_imperdiet-_erat_vitae_rhoncus_iaculis-_metus_libero_accumsan_sapien-_nec_convallis_nisl_mauris_at_enim._Quisque_dui_lacus-_mollis_ac_ultricies_id-_facilisis_at_nunc._Integer_ullamcorper_in_elit_eget_volutpat._Curabitur_tristique-_metus_sed_tincidunt_egestas-_leo_velit_facilisis_turpis-_eu_auctor_ligula_magna_varius_est._Fusce_iaculis_convallis_sapien_et_accumsan._Curabitur_tortor_nisl-_varius_nec_posuere_non-_fringilla_ut_metus_tortor_nisl-_varius_nec_posuere_non-_fringilla_ut_metus';
+  static const MOCK_RESPONSE = CreateUrlResponse(
+    url:
+        'https://noclick.me/_test/Lorem_ipsum_dolor_sit_amet-_consectetur_adipiscing_elit._Ut_odio_felis-_maximus_eget_ex_nec-_varius_efficitur_lorem._Donec_imperdiet-_erat_vitae_rhoncus_iaculis-_metus_libero_accumsan_sapien-_nec_convallis_nisl_mauris_at_enim._Quisque_dui_lacus-_mollis_ac_ultricies_id-_facilisis_at_nunc._Integer_ullamcorper_in_elit_eget_volutpat._Curabitur_tristique-_metus_sed_tincidunt_egestas-_leo_velit_facilisis_turpis-_eu_auctor_ligula_magna_varius_est._Fusce_iaculis_convallis_sapien_et_accumsan._Curabitur_tortor_nisl-_varius_nec_posuere_non-_fringilla_ut_metus_tortor_nisl-_varius_nec_posuere_non-_fringilla_ut_metus',
+    rateLimit: RateLimitInfo(
+      limit: 10,
+      remaining: 9,
+      reset: Duration(seconds: 10),
+    ),
+  );
 
   final Uri _serverUrl;
 
@@ -21,7 +115,7 @@ class NoClickService {
             Uri.parse(const String.fromEnvironment(SERVER_URL_VAR_NAME,
                 defaultValue: SERVER_URL_DEFAULT));
 
-  Future<String> createUrl(Uri url) async {
+  Future<CreateUrlResponse> createUrl(Uri url) async {
     final mockResponse = const String.fromEnvironment(MOCK_RESPONSE_VAR_NAME);
     if (mockResponse.toLowerCase() == 'true' || mockResponse == '1') {
       print('Mocking response: ${MOCK_RESPONSE}');
@@ -35,10 +129,36 @@ class NoClickService {
           'url': url.toString(),
         }));
 
-    if (response.statusCode != 200) {
-      return 'NOT OK: status=${response.statusCode}';
+    // Try to get rate limit information. We just bail out on any errors (in
+    // which case rateLimit will be passed as null to the CreateUrlResponse.
+    final rateLimit = _RateLimitInfoBuilder();
+    try {
+      if (response.headers.containsKey('x-ratelimit-limit')) {
+        rateLimit.limit = int.parse(response.headers['x-ratelimit-limit']);
+      }
+      if (response.headers.containsKey('x-ratelimit-remaining')) {
+        rateLimit.remaining =
+            int.parse(response.headers['x-ratelimit-remaining']);
+      }
+      if (response.headers.containsKey('x-ratelimit-reset')) {
+        rateLimit.reset =
+            Duration(seconds: int.parse(response.headers['x-ratelimit-reset']));
+      }
+    } on FormatException {
+      // Ignore, even when this shouldn't happen, is not something the user have
+      // to care about.
     }
 
-    return jsonDecode(response.body)['noclick_url'].toString();
+    if (response.statusCode != 200) {
+      return CreateUrlResponse.error(
+        'Unable to create new URL, status=${response.statusCode}',
+        rateLimit: rateLimit.finish(),
+      );
+    }
+
+    return CreateUrlResponse(
+      url: jsonDecode(response.body)['noclick_url'].toString(),
+      rateLimit: rateLimit.finish(),
+    );
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -73,10 +73,10 @@ class Home extends StatelessWidget {
                       top: 0.05.sh,
                     ),
                     child: UrlForm(
-                      onSuccess: (url) => Navigator.push<ShowUrlScreen>(
+                      onSuccess: (response) => Navigator.push<ShowUrlScreen>(
                         context,
                         MaterialPageRoute(
-                          builder: (context) => ShowUrlScreen(url),
+                          builder: (context) => ShowUrlScreen(response),
                         ),
                       ),
                     ),

--- a/lib/url_form.dart
+++ b/lib/url_form.dart
@@ -3,11 +3,11 @@ import 'dart:async' show FutureOr;
 import 'package:flutter/material.dart' hide HttpClientProvider;
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-import 'net.dart' show NoClickService;
+import 'net.dart' show NoClickService, CreateUrlResponse;
 import 'provider/http_client_provider.dart' show HttpClientProvider;
 
 class UrlForm extends StatefulWidget {
-  final FutureOr<void> Function(String url) onSuccess;
+  final FutureOr<void> Function(CreateUrlResponse createUrlResponse) onSuccess;
   UrlForm({this.onSuccess, Key key}) : super(key: key);
 
   @override
@@ -132,15 +132,15 @@ class _UrlFormState extends State<UrlForm> {
       final service =
           NoClickService(httpClient: HttpClientProvider.of(context).client);
 
-      String url;
+      CreateUrlResponse response;
       try {
-        url = await service.createUrl(uri);
+        response = await service.createUrl(uri);
       } catch (e) {
         ScaffoldMessenger.of(context)
           ..hideCurrentSnackBar()
           ..showSnackBar(
             SnackBar(
-              content: Text('Could not retrieve the page: ${e.message}'),
+              content: Text('Could not retrieve the page: ${e}'),
             ),
           );
         _fieldFocusNode.requestFocus();
@@ -156,7 +156,7 @@ class _UrlFormState extends State<UrlForm> {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
 
       if (widget.onSuccess != null) {
-        await widget.onSuccess(url);
+        await widget.onSuccess(response);
       }
 
       setState(() => _fieldController.clear());

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.3"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   build:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.5"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   cli_util:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.5"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
@@ -120,13 +120,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.10"
+  duration:
+    dependency: "direct main"
+    description:
+      name: duration
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.15"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   file:
     dependency: transitive
     description:
@@ -153,6 +160,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.2"
   flutter_screenutil:
     dependency: "direct main"
     description:
@@ -211,7 +225,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.3"
+    version: "0.6.3"
   linkify:
     dependency: transitive
     description:
@@ -226,20 +240,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.4"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.3"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.6"
+    version: "1.3.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -274,7 +295,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
@@ -321,49 +342,49 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.4"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.6"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.3"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.6"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0"
   url_launcher:
     dependency: "direct main"
     description:
@@ -412,7 +433,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.5"
+    version: "2.1.0"
   watcher:
     dependency: transitive
     description:
@@ -429,4 +450,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.22.0 <2.0.0"
+  flutter: ">=1.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,12 @@ environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
+  duration: ^2.0.15
   flutter:
     sdk: flutter
-  flutter_screenutil: ^3.2.0
+  flutter_markdown: ^0.5.2
   flutter_linkify: ^4.0.2
+  flutter_screenutil: ^3.2.0
   http: ^0.12.2
   url_launcher: ^5.7.10
 

--- a/test/unit/net_test.dart
+++ b/test/unit/net_test.dart
@@ -12,23 +12,110 @@ void main() {
       expect(service.serverUrl, Uri.parse(NoClickService.SERVER_URL_DEFAULT));
       expect(service.httpClient, same(client));
       expect(() => NoClickService(httpClient: null), throwsAssertionError);
+      expect(() => CreateUrlResponse(url: null), throwsAssertionError);
+      expect(() => CreateUrlResponse.error(null), throwsAssertionError);
+      expect(
+          () => RateLimitInfo(limit: null, remaining: 1, reset: Duration.zero),
+          throwsAssertionError);
+      expect(
+          () => RateLimitInfo(limit: 1, remaining: null, reset: Duration.zero),
+          throwsAssertionError);
+      expect(() => RateLimitInfo(limit: 1, remaining: 1, reset: null),
+          throwsAssertionError);
     });
 
-    test('createUrl()', () async {
+    test('toString()', () {
+      expect(
+          RateLimitInfo(limit: 1, remaining: 2, reset: Duration.zero)
+              .toString(),
+          'RateLimitInfo(limit: 1, remaining: 2, reset: 0:00:00.000000)');
+    });
+
+    group('createUrl()', () {
       final url = Uri.parse('https://example.com');
       final noclickUrl = 'https://some.long/url';
 
-      var client = MockClient(
-        (req) async => http.Response('{"noclick_url": "$noclickUrl"}', 200),
-      );
-      expect(
-          await NoClickService(httpClient: client).createUrl(url), noclickUrl);
+      Map<String, String> limits({
+        String limit,
+        String remaining,
+        String reset,
+      }) {
+        final r = <String, String>{};
+        if (limit != null) r['x-ratelimit-limit'] = limit;
+        if (remaining != null) r['x-ratelimit-remaining'] = remaining;
+        if (reset != null) r['x-ratelimit-reset'] = reset;
+        return r;
+      }
 
-      client = MockClient(
-        (req) async => http.Response('BAD', 400),
-      );
-      expect(await NoClickService(httpClient: client).createUrl(url),
-          'NOT OK: status=400');
+      test('OK, no ratelimit', () async {
+        final client = MockClient(
+          (req) async => http.Response('{"noclick_url": "$noclickUrl"}', 200),
+        );
+        final response =
+            await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, noclickUrl);
+        expect(response.error, isNull);
+        expect(response.rateLimit, isNull);
+      });
+
+      test('BAD, no ratelimit', () async {
+        final client = MockClient(
+          (req) async => http.Response('BAD', 400),
+        );
+        final response =
+            await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, isNull);
+        expect(response.error, 'Unable to create new URL, status=400');
+        expect(response.rateLimit, isNull);
+      });
+
+      test('OK, with ratelimit', () async {
+        var client = MockClient(
+          (req) async => http.Response('{"noclick_url": "$noclickUrl"}', 200,
+              headers: limits(limit: '10', remaining: '123', reset: '10')),
+        );
+        var response = await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, noclickUrl);
+        expect(response.error, isNull);
+        expect(response.rateLimit.limit, 10);
+        expect(response.rateLimit.remaining, 123);
+        expect(response.rateLimit.reset, Duration(seconds: 10));
+      });
+
+      test('BAD, with ratelimit', () async {
+        var client = MockClient(
+          (req) async => http.Response('BAD', 400,
+              headers: limits(limit: '10', remaining: '123', reset: '10')),
+        );
+        var response = await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, isNull);
+        expect(response.error, 'Unable to create new URL, status=400');
+        expect(response.rateLimit.limit, 10);
+        expect(response.rateLimit.remaining, 123);
+        expect(response.rateLimit.reset, Duration(seconds: 10));
+      });
+
+      test('OK, with missing ratelimit values', () async {
+        var client = MockClient(
+          (req) async => http.Response('{"noclick_url": "$noclickUrl"}', 200,
+              headers: limits(limit: '10', reset: '10')),
+        );
+        var response = await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, noclickUrl);
+        expect(response.error, isNull);
+        expect(response.rateLimit, isNull);
+      });
+
+      test('OK, with wrong ratelimit values', () async {
+        var client = MockClient(
+          (req) async => http.Response('{"noclick_url": "$noclickUrl"}', 200,
+              headers: limits(limit: '10', remaining: 'not many', reset: '10')),
+        );
+        var response = await NoClickService(httpClient: client).createUrl(url);
+        expect(response.url, noclickUrl);
+        expect(response.error, isNull);
+        expect(response.rateLimit, isNull);
+      });
     });
   });
 }

--- a/tool/ci
+++ b/tool/ci
@@ -20,6 +20,7 @@ cmd_ci() {
 }
 
 cmd_check() {
+  flutter pub get
   cmd_format
   cmd_analyze
 }

--- a/tool/ci
+++ b/tool/ci
@@ -86,7 +86,7 @@ cmd_cov_check() {
 
   echo
   echo "HTML coverage report available at:"
-  echo "$PWD/coverage/html/index.html"
+  echo "file://$PWD/coverage/html/index.html"
 
   if test "$cov" -lt "$MIN_COV_PCT"
   then

--- a/tool/ci
+++ b/tool/ci
@@ -15,9 +15,7 @@ main() {
 
 cmd_ci() {
   cmd_check
-  cmd_test_unit
-  cmd_test_goldens
-  cmd_test_special
+  cmd_test
   cmd_cov_check
 }
 
@@ -33,6 +31,12 @@ cmd_analyze() {
 cmd_format() {
   echo "Checking format..."
   flutter format -n --set-exit-if-changed lib test
+}
+
+cmd_test() {
+  cmd_test_unit
+  cmd_test_goldens
+  cmd_test_special
 }
 
 test_normal() {

--- a/tool/ci
+++ b/tool/ci
@@ -72,7 +72,7 @@ cmd_test_special() {
 
 cmd_cov_check() {
   echo "Generating coverage report..."
-  genhtml coverage/*.lcov.info --output-directory coverage/html
+  genhtml coverage/*.lcov.info --no-function-coverage --output-directory coverage/html
 
   cov=$(sed -n 's|.*<td class="headerCovTableEntryHi">\([0-9]\+\)\(\.[0-9]\+\)\? %</td>.*|\1|p' coverage/html/index.html)
   r=0

--- a/tool/ci
+++ b/tool/ci
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-MIN_COV_PCT=${MIN_COV_PCT:-92}
+MIN_COV_PCT=${MIN_COV_PCT:-96}
 
 main() {
   # Run the ci command if none was specified


### PR DESCRIPTION
- Migrate FlatButton to TextButton
- tool/ci: Add a plain test command
- tool/ci: Add flutter pub get as part of check
- tool/ci: Don't output function coverage
- tool/ci: Make coverage report a valid URL
- Update goldens due to flutter changes
- Show rate limit information
- tool/ci: Increase minimum required coverage to 96%
