### PR TITLE
codecov: Add patch configuration and relax settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,9 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 0%
+        target: 98%
+        threshold: 0.5%
+    patch:
+      default:
+        target: 90%
 comment: false


### PR DESCRIPTION
We allow to reduce coverage by a 0.5% and require only a minimum of 96% for the whole project, as sometimes it is very impractical to test everything.

In particular with patches, as the project starts growing, it can happen that a small patch have some code that is very impractical to test fully, so we even allow a 90% coverage for patches.