### PR TITLE
Fix handling of CreateUrlResponse.error

### DIFF
--- a/lib/net.dart
+++ b/lib/net.dart
@@ -87,6 +87,10 @@ class CreateUrlResponse {
   const CreateUrlResponse.error(this.error, {this.rateLimit})
       : assert(error != null),
         url = null;
+
+  @override
+  String toString() =>
+      '$runtimeType(url: $url, error: $error, rateLimit: $rateLimit)';
 }
 
 class NoClickService {

--- a/lib/url_form.dart
+++ b/lib/url_form.dart
@@ -153,6 +153,22 @@ class _UrlFormState extends State<UrlForm> {
         setState(() => _submitting = false);
       }
 
+      if (response.error != null) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(
+              content: Text('The URL could not be expanded: ${response.error}'),
+            ),
+          );
+        _fieldFocusNode.requestFocus();
+        _fieldController.selection = TextSelection(
+          baseOffset: 0,
+          extentOffset: _fieldController.text.length,
+        );
+        return;
+      }
+
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
 
       if (widget.onSuccess != null) {

--- a/test/unit/net_test.dart
+++ b/test/unit/net_test.dart
@@ -25,10 +25,24 @@ void main() {
     });
 
     test('toString()', () {
-      expect(
-          RateLimitInfo(limit: 1, remaining: 2, reset: Duration.zero)
-              .toString(),
+      final rateLimit =
+          RateLimitInfo(limit: 1, remaining: 2, reset: Duration.zero);
+      expect(rateLimit.toString(),
           'RateLimitInfo(limit: 1, remaining: 2, reset: 0:00:00.000000)');
+      expect(
+          CreateUrlResponse(url: 'https://example.com').toString(),
+          'CreateUrlResponse(url: https://example.com, error: null, '
+          'rateLimit: null)');
+      expect(
+          CreateUrlResponse.error('BAD!').toString(),
+          'CreateUrlResponse(url: null, error: BAD!, '
+          'rateLimit: null)');
+      expect(
+          CreateUrlResponse(url: 'https://example.com', rateLimit: rateLimit)
+              .toString(),
+          'CreateUrlResponse(url: https://example.com, error: null, '
+          'rateLimit: RateLimitInfo(limit: 1, remaining: 2, '
+          'reset: 0:00:00.000000))');
     });
 
     group('createUrl()', () {

--- a/test/unit/url_form_test.dart
+++ b/test/unit/url_form_test.dart
@@ -174,7 +174,7 @@ void main() {
         await tester.pump(Duration(seconds: 4)); // Default SnackBar duration
         await tester.pumpAndSettle();
         expect(find.byType(SnackBar), findsNothing);
-      }); // FIXME: I CAN'T FIND THE SNACKBAR with the error
+      });
     });
 
     group('succeeds', () {

--- a/test/unit/url_form_test.dart
+++ b/test/unit/url_form_test.dart
@@ -145,10 +145,21 @@ void main() {
           find.byType(TextFormField),
           'https://example.com',
         );
+        expect(find.byType(SnackBar), findsNothing);
 
         await tester.testTextInput.receiveAction(TextInputAction.done);
-        await tester.pumpAndSettle(); // Wait for the new screen animation
-        expect(response.error, 'Unable to create new URL, status=400');
+        await tester.pumpAndSettle(); // Wait for the SnackBar in animation
+        expect(response, isNull);
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(
+            find.text('The URL could not be expanded: '
+                'Unable to create new URL, status=400'),
+            findsOneWidget);
+
+        await tester.pump(Duration(seconds: 4)); // Default SnackBar duration
+        await tester.pumpAndSettle();
+        expect(response, isNull);
+        expect(find.byType(SnackBar), findsNothing);
       });
 
       testWidgets('there is an unexpected exception in net',


### PR DESCRIPTION
In previous changes the `CreateUrlResponse.error` attribute was added, but it wasn't properly handled when processing the `UrlForm` and it was being ignored, ending up in weird unrelated errors when trying to show an expanded URL that was never created.

Fixes #38.