### PR TITLE
ci: Switch to Flutter stable channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   JAVA_VERSION: 12.x
-  FLUTTER_CHANNEL: beta
+  FLUTTER_CHANNEL: stable
 
 jobs:
   test:
@@ -83,10 +83,6 @@ jobs:
       uses: subosito/flutter-action@v1
       with:
         channel: ${{ env.FLUTTER_CHANNEL }}
-
-    - name: Enable Flutter web
-      if: ${{ matrix.target == 'web' }}
-      run: flutter config --enable-web
 
     - name: Install dependencies
       run: flutter pub get


### PR DESCRIPTION
Now that Flutter 2 was released, the web platform is in stable and desktop platforms are included as a beta snapshot, so there is even no need to be on beta to get desktop (although desktop updates will flow into stable much more slowly than in beta).

Fixes #42.