### PR TITLE
codecov: Lower coverage requirements

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,9 +5,9 @@ coverage:
   status:
     project:
       default:
-        target: 98%
-        threshold: 0.5%
+        target: 95%
+        threshold: 2.5%
     patch:
       default:
-        target: 90%
+        target: 85%
 comment: false


### PR DESCRIPTION
Set 95% for the whole project and 85% for patches. The current limits are too high and it is sometimes not practical to cover that much, as it has a very low ROI.