### PR TITLE
web: Add social media previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       if: ${{ matrix.target == 'linux' }}
       run: flutter config --enable-linux-desktop
 
-    - name: Install pub dependencies
+    - name: Install Linux dependencies
       if: matrix.target == 'linux'
       run: sudo apt-get install
         clang
@@ -102,7 +102,7 @@ jobs:
         libblkid-dev
         liblzma-dev
 
-    - name: Install Linux dependencies
+    - name: Install pub dependencies
       run: flutter pub get
 
     - name: Build multi-arch apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
       if: ${{ matrix.target == 'linux' }}
       run: flutter config --enable-linux-desktop
 
+    - name: Install Web dependencies
+      if: matrix.target == 'web'
+      run: sudo apt-get install
+        pandoc
+
     - name: Install Linux dependencies
       if: matrix.target == 'linux'
       run: sudo apt-get install
@@ -136,7 +141,7 @@ jobs:
       if: matrix.target == 'web'
       run: |
         TARGET=${{ matrix.target }}
-        flutter build $TARGET --release
+        tool/ci build_${TARGET}
         mkdir -p artifacts
         mv build/web artifacts/$TARGET
 

--- a/tool/ci
+++ b/tool/ci
@@ -13,6 +13,17 @@ main() {
   done
 }
 
+cmd_build() {
+  cmd_build_web
+}
+
+cmd_build_web() {
+  flutter build web --release
+  pandoc --from markdown --to html --standalone \
+    --metadata "title=noclick.me - Privacy Policy" \
+    doc/legal/privacy.md > build/web/privacy.html
+}
+
 cmd_ci() {
   cmd_check
   cmd_test

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns#">
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -22,6 +22,33 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="noclick.me">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
+
+  <!-- OpenGraph metadata (https://ogp.me/) -->
+  <meta property="og:site_name" content="noclick.me" />
+  <meta property="og:title" content="noclick.me" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://app.noclick.me/" />
+  <meta property="og:description" content="Never click on a link again! noclick.me is a URL expander. It retrieves the link contents and create a long descriptive URL with the most relevant information in it, so people can decide if they want to follow the link or not." />
+  <meta property="og:image" content="https://app.noclick.me/icons/Banner-1024x500.png" />
+  <meta property="og:image:width" content="1024" />
+  <meta property="og:image:height" content="500" />
+  <meta property="og:image:alt" content="A hand pointing up with a red cross on top with the text 'noclick.me. Never click on a link again!' and some background long URL" />
+  <meta property="og:image" content="https://app.noclick.me/icons/Icon-512.png" />
+  <meta property="og:image:width" content="512" />
+  <meta property="og:image:height" content="512" />
+  <meta property="og:image:alt" content="A hand pointing up with a red cross on top" />
+  <meta property="og:image" content="https://app.noclick.me/icons/Icon-192.png" />
+  <meta property="og:image:width" content="192" />
+  <meta property="og:image:height" content="192" />
+  <meta property="og:image:alt" content="A hand pointing up with a red cross on top" />
+
+  <!-- Twitter card (https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:site" content="noclick_me">
+  <meta property="twitter:description" content="A URL expander that retrieves the link contents and create a long descriptive URL with the most relevant information in it, so people can decide if they want to follow the link or not.">
+  <meta property="twitter:image" content="https://app.noclick.me/icons/Banner-1024x500.png">
+  <meta property="twitter:image:width" content="1024" />
+  <meta property="twitter:image:height" content="500" />
 
   <!-- Favicon -->
   <link rel="shortcut icon" type="image/png" href="favicon.png"/>


### PR DESCRIPTION
Uses OpenGraph (https://ogp.me/) and Twitter Cards (https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup) to generate social media previews for the link.

Improves on #13 and #52.