### PR TITLE
Migrate to null-safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,9 @@ jobs:
     - name: Setup
       run: tool/ci setup
 
-    - name: Analyze
+    - name: Static checks
       if: matrix.type == 'static'
-      uses: zgosalvez/github-actions-analyze-flutter@v1
-      with:
-        fail-on-warnings: true
+      run: tool/ci check
 
     - name: Run ${{ matrix.type }} tests
       if: matrix.type != 'static'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       with:
         channel: ${{ env.FLUTTER_CHANNEL }}
 
-    - name: Install dependencies
-      run: flutter pub get
+    - name: Setup
+      run: tool/ci setup
 
     - name: Analyze
       if: matrix.type == 'static'

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 .pub-cache/
 .pub/
 /build/
+test/**/*.mocks.dart
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,8 @@
 include: package:pedantic/analysis_options.1.9.0.yaml
 
 analyzer:
+  exclude:
+    - '**.mocks.dart'
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,7 +4,7 @@ import 'screens/home.dart' show Home;
 import 'screenutil_builder.dart' show screenutilBuilder;
 
 class App extends StatelessWidget {
-  const App({Key key}) : super(key: key);
+  const App({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) => MaterialApp(

--- a/lib/launch_url.dart
+++ b/lib/launch_url.dart
@@ -2,24 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart' show canLaunch, launch;
 
 /// Opens [url] in a browser/new tab) or shows an error if it can't be opened.
-void launchUrl(String url, BuildContext context) async {
-  String error;
+void launchUrl(String? url, BuildContext context) async {
+  void showError(String error) => ScaffoldMessenger.of(context)
+    ..removeCurrentSnackBar()
+    ..showSnackBar(
+      SnackBar(
+        content: Text(error),
+      ),
+    );
+
+  if (url == null) {
+    showError("Can't open a null URL");
+    return;
+  }
+
   try {
     if (!await canLaunch(url) ||
         !await launch(url, forceWebView: true, enableJavaScript: true)) {
-      error = "Don't know how to open this URL type";
+      showError("Don't know how to open this URL type");
     }
   } catch (e) {
-    error = "Can't open URL: $e";
-  }
-
-  if (error != null) {
-    ScaffoldMessenger.of(context)
-      ..removeCurrentSnackBar()
-      ..showSnackBar(
-        SnackBar(
-          content: Text(error),
-        ),
-      );
+    showError("Can't open URL: $e");
   }
 }

--- a/lib/logo.dart
+++ b/lib/logo.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class Logo extends StatelessWidget {
-  const Logo({Key key}) : super(key: key);
+  const Logo({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/markdown_asset.dart
+++ b/lib/markdown_asset.dart
@@ -17,14 +17,11 @@ class MarkdownAsset extends StatelessWidget {
 
   /// Creates a new markdown widget from [location].
   const MarkdownAsset(
-      {@required this.location,
+      {required this.location,
       this.standalone = true,
       this.textAlign = WrapAlignment.spaceBetween,
-      Key key})
-      : assert(location != null),
-        assert(standalone != null),
-        assert(textAlign != null),
-        super(key: key);
+      Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) => FutureBuilder<String>(
@@ -36,13 +33,13 @@ class MarkdownAsset extends StatelessWidget {
 
             if (standalone) {
               return Markdown(
-                data: snapshot.data,
+                data: snapshot.data!,
                 styleSheet: style,
                 onTapLink: (text, href, title) => launchUrl(href, context),
               );
             }
             return MarkdownBody(
-              data: snapshot.data,
+              data: snapshot.data!,
               styleSheet: style,
               onTapLink: (text, href, title) => launchUrl(href, context),
             );

--- a/lib/net.dart
+++ b/lib/net.dart
@@ -1,5 +1,4 @@
 import 'dart:convert' show jsonEncode, jsonDecode;
-import 'package:meta/meta.dart' show required;
 import 'package:http/http.dart' as http;
 
 /// Information about current rate limits.
@@ -19,12 +18,10 @@ class RateLimitInfo {
   ///
   /// All arguments should be non-null.
   const RateLimitInfo({
-    @required this.limit,
-    @required this.remaining,
-    @required this.reset,
-  })  : assert(limit != null),
-        assert(remaining != null),
-        assert(reset != null);
+    required this.limit,
+    required this.remaining,
+    required this.reset,
+  });
 
   @override
   String toString() => '$runtimeType(limit: $limit, remaining: $remaining, '
@@ -40,9 +37,9 @@ class RateLimitInfo {
 /// After assigning all values, just call [finish] to get the valid
 /// [RateLimitInfo] or null if it's invalid.
 class _RateLimitInfoBuilder {
-  int limit;
-  int remaining;
-  Duration reset;
+  int? limit;
+  int? remaining;
+  Duration? reset;
   _RateLimitInfoBuilder({
     this.limit,
     this.remaining,
@@ -52,8 +49,8 @@ class _RateLimitInfoBuilder {
   /// Returns the built [RateLimitInfo].
   ///
   /// If any field is missing, then it returns null.
-  RateLimitInfo finish() => limit != null && remaining != null && reset != null
-      ? RateLimitInfo(limit: limit, remaining: remaining, reset: reset)
+  RateLimitInfo? finish() => limit != null && remaining != null && reset != null
+      ? RateLimitInfo(limit: limit!, remaining: remaining!, reset: reset!)
       : null;
 }
 
@@ -62,31 +59,29 @@ class CreateUrlResponse {
   /// The created URL.
   ///
   /// Can be null if [error] is non-null.
-  final String url;
+  final String? url;
 
   /// An error trying to create the URL.
   ///
   /// Is null if there was no error creating the URL.
-  final String error;
+  final String? error;
 
   /// Rate limit information associated with the response.
   ///
   /// Can be null if there was no rate limit information.
-  final RateLimitInfo rateLimit;
+  final RateLimitInfo? rateLimit;
 
   /// Creates a successful [CreateUrlResponse].
   ///
   /// [url] can't be null and [error] will be set to null.
-  const CreateUrlResponse({@required this.url, this.rateLimit})
-      : assert(url != null),
-        error = null;
+  const CreateUrlResponse({required String this.url, this.rateLimit})
+      : error = null;
 
   /// Creates an failed [CreateUrlResponse].
   ///
   /// [error] can't be null and [url] will be set to null.
-  const CreateUrlResponse.error(this.error, {this.rateLimit})
-      : assert(error != null),
-        url = null;
+  const CreateUrlResponse.error(String this.error, {this.rateLimit})
+      : url = null;
 
   @override
   String toString() =>
@@ -113,9 +108,8 @@ class NoClickService {
 
   final http.Client httpClient;
 
-  NoClickService({@required this.httpClient, Uri serverUrl})
-      : assert(httpClient != null),
-        _serverUrl = serverUrl ??
+  NoClickService({required this.httpClient, Uri? serverUrl})
+      : _serverUrl = serverUrl ??
             Uri.parse(const String.fromEnvironment(SERVER_URL_VAR_NAME,
                 defaultValue: SERVER_URL_DEFAULT));
 
@@ -138,15 +132,15 @@ class NoClickService {
     final rateLimit = _RateLimitInfoBuilder();
     try {
       if (response.headers.containsKey('x-ratelimit-limit')) {
-        rateLimit.limit = int.parse(response.headers['x-ratelimit-limit']);
+        rateLimit.limit = int.parse(response.headers['x-ratelimit-limit']!);
       }
       if (response.headers.containsKey('x-ratelimit-remaining')) {
         rateLimit.remaining =
-            int.parse(response.headers['x-ratelimit-remaining']);
+            int.parse(response.headers['x-ratelimit-remaining']!);
       }
       if (response.headers.containsKey('x-ratelimit-reset')) {
-        rateLimit.reset =
-            Duration(seconds: int.parse(response.headers['x-ratelimit-reset']));
+        rateLimit.reset = Duration(
+            seconds: int.parse(response.headers['x-ratelimit-reset']!));
       }
     } on FormatException {
       // Ignore, even when this shouldn't happen, is not something the user have

--- a/lib/provider/http_client_provider.dart
+++ b/lib/provider/http_client_provider.dart
@@ -4,14 +4,12 @@ import 'package:http/http.dart' as http;
 class HttpClientProvider extends InheritedWidget {
   final http.Client client;
   const HttpClientProvider({
-    Key key,
-    @required this.client,
-    @required Widget child,
-  })  : assert(client != null),
-        assert(child != null),
-        super(key: key, child: child);
+    Key? key,
+    required this.client,
+    required Widget child,
+  }) : super(key: key, child: child);
 
-  static HttpClientProvider of(BuildContext context) =>
+  static HttpClientProvider? of(BuildContext context) =>
       context.dependOnInheritedWidgetOfExactType<HttpClientProvider>();
 
   @override

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -10,19 +10,19 @@ import 'show.dart' show ShowUrlScreen;
 import 'privacy_policy.dart' show PrivacyPolicyScreen;
 
 class Home extends StatelessWidget {
-  const Home({Key key}) : super(key: key);
+  const Home({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final topPadding = SizedBox(height: 0.04.sh);
 
     double adapt({
-      num current,
-      num atMost,
-      num smallerThan,
-      double thenUse,
-      double andUse,
-      num ifBiggerThan,
+      required num current,
+      required num smallerThan,
+      required double thenUse,
+      required double andUse,
+      required num ifBiggerThan,
+      num? atMost,
     }) {
       final minPixels = smallerThan;
       final maxPixels = ifBiggerThan;

--- a/lib/screens/privacy_policy.dart
+++ b/lib/screens/privacy_policy.dart
@@ -4,7 +4,7 @@ import '../markdown_asset.dart' show MarkdownAsset;
 
 /// Shows a Privacy Policy Screen.
 class PrivacyPolicyScreen extends StatelessWidget {
-  const PrivacyPolicyScreen({Key key}) : super(key: key);
+  const PrivacyPolicyScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/show.dart
+++ b/lib/screens/show.dart
@@ -21,9 +21,7 @@ class ShowUrlScreen extends StatelessWidget {
   // abstraction until this changes (if it does).
   final CreateUrlResponse response;
 
-  const ShowUrlScreen(this.response, {Key key})
-      : assert(response != null),
-        super(key: key);
+  const ShowUrlScreen(this.response, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -66,7 +64,7 @@ class ShowUrlScreen extends StatelessWidget {
                                   icon: const Icon(Icons.open_in_new),
                                   label: const Text('OPEN'),
                                   onPressed: () =>
-                                      launchUrl(response.url, context),
+                                      launchUrl(response.url!, context),
                                 ),
                                 SizedBox(width: 8.w),
                                 TextButton.icon(
@@ -96,14 +94,14 @@ class ShowUrlScreen extends StatelessWidget {
                                 // do char-by-char wrapping in Flutter.
                                 // This should eventually be
                                 // TextAlign.justify too.
-                                text: response.url.replaceAll('-', '\u2011'),
+                                text: response.url!.replaceAll('-', '\u2011'),
                                 options: LinkifyOptions(
                                   humanize: false,
                                   defaultToHttps: true,
                                   excludeLastPeriod: false,
                                 ),
                                 onOpen: (link) =>
-                                    launchUrl(response.url, context),
+                                    launchUrl(response.url!, context),
                               ),
                             ),
                           ],
@@ -117,7 +115,7 @@ class ShowUrlScreen extends StatelessWidget {
                       horizontal: 25.w,
                     ),
                     child: response.rateLimit != null
-                        ? RateLimitMessage(response.rateLimit)
+                        ? RateLimitMessage(response.rateLimit!)
                         : Container(),
                   ),
                 ],
@@ -138,7 +136,7 @@ class RateLimitMessage extends StatelessWidget {
   /// Creates a [RateLimitMessage].
   ///
   /// [limit] must be non-null.
-  const RateLimitMessage(this.limit) : assert(limit != null);
+  const RateLimitMessage(this.limit);
 
   /// Shows the [limit.reset] information in a human readable form.
   String get reset =>
@@ -146,7 +144,7 @@ class RateLimitMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => MarkdownBody(
-        onTapLink: (text, href, title) => launchUrl(href, context),
+        onTapLink: (text, href, title) => launchUrl(href!, context),
         styleSheet: MarkdownStyleSheet(textAlign: WrapAlignment.spaceBetween),
         data: '''\
 There are **${limit.remaining}** requests left for today (will be reset to

--- a/lib/screenutil_builder.dart
+++ b/lib/screenutil_builder.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
-Widget screenutilBuilder({@required Widget child}) => ScreenUtilInit(
+Widget screenutilBuilder({required Widget child}) => ScreenUtilInit(
       designSize: Size(1080, 1920),
       builder: () => child,
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.0.0"
   built_collection:
     dependency: transitive
     description:
@@ -71,6 +106,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   cli_util:
     dependency: transitive
     description:
@@ -184,6 +226,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   glob:
     dependency: transitive
     description:
@@ -198,6 +247,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   http:
     dependency: "direct main"
     description:
@@ -205,6 +261,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.2"
+  http_multi_server:
+    dependency: transitive
+    description:
+      name: http_multi_server
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
@@ -212,6 +275,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  io:
+    dependency: transitive
+    description:
+      name: io
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   js:
     dependency: transitive
     description:
@@ -219,6 +289,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   linkify:
     dependency: transitive
     description:
@@ -254,6 +331,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   mockito:
     dependency: "direct dev"
     description:
@@ -289,6 +373,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  pool:
+    dependency: transitive
+    description:
+      name: pool
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -296,6 +387,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  shelf:
+    dependency: transitive
+    description:
+      name: shelf
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
+  shelf_web_socket:
+    dependency: transitive
+    description:
+      name: shelf_web_socket
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -329,6 +441,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -350,6 +469,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.19"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:
@@ -413,6 +539,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 0.3.0
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   duration: ^3.0.6
@@ -20,6 +20,7 @@ dependencies:
   url_launcher: ^6.0.3
 
 dev_dependencies:
+  build_runner: ^2.0.2
   flutter_test:
     sdk: flutter
   golden_toolkit: ^0.9.0

--- a/test/unit/launch_url_test.dart
+++ b/test/unit/launch_url_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart'
     show MockPlatformInterfaceMixin;
@@ -8,14 +9,20 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 
 import 'package:noclick_me/launch_url.dart';
 
-class MockUrlLauncher extends Mock
-    with MockPlatformInterfaceMixin
-    implements UrlLauncherPlatform {}
+import 'launch_url_test.mocks.dart';
 
+class MockUrlLauncherPlatform extends MockUrlLauncherPlatformBase
+    with MockPlatformInterfaceMixin {}
+
+// TODO: remove returnNullOnMissingStub
+@GenerateMocks([], customMocks: [
+  MockSpec<UrlLauncherPlatform>(
+      as: #MockUrlLauncherPlatformBase, returnNullOnMissingStub: true),
+])
 void main() {
   group('launchUrl()', () {
     // Mock the url_launcher service
-    final mockLauncher = MockUrlLauncher();
+    final mockLauncher = MockUrlLauncherPlatform();
     final oldInstance = UrlLauncherPlatform.instance;
     UrlLauncherPlatform.instance = mockLauncher;
 
@@ -156,7 +163,7 @@ void main() {
         headers: anyNamed('headers'),
         universalLinksOnly: anyNamed('universalLinksOnly'),
         webOnlyWindowName: anyNamed('webOnlyWindowName'),
-      )).thenAnswer((_) async => throw Exception('LaunchException'));
+      )).thenAnswer(((_) async => throw Exception('LaunchException')));
       await tester.tap(buttonFinder);
       await tester.pump();
       verify(mockLauncher.canLaunch(mockUrl)).called(1);

--- a/test/unit/markdown_asset_test.dart
+++ b/test/unit/markdown_asset_test.dart
@@ -5,10 +5,6 @@ import 'package:noclick_me/markdown_asset.dart';
 
 void main() {
   group('MarkdownAsset', () {
-    test('constructor asserts on bad arguments', () {
-      expect(() => MarkdownAsset(location: null), throwsAssertionError);
-    });
-
     testWidgets('invalid asset shows error', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(

--- a/test/unit/provider/http_client_provider_test.dart
+++ b/test/unit/provider/http_client_provider_test.dart
@@ -6,23 +6,7 @@ import 'package:noclick_me/provider/http_client_provider.dart';
 
 void main() {
   group('HttpClientProvider', () {
-    final mockClient = MockClient((r) => null);
-
-    testWidgets('constructor asserts on null required parameters',
-        (WidgetTester tester) async {
-      expect(
-        () => HttpClientProvider(client: null, child: Container()),
-        throwsAssertionError,
-      );
-      expect(
-        () => HttpClientProvider(child: null, client: mockClient),
-        throwsAssertionError,
-      );
-      expect(
-        () => HttpClientProvider(child: null, client: null),
-        throwsAssertionError,
-      );
-    });
+    final mockClient = MockClient(((r) => Future.value(null)));
 
     testWidgets('child is built when pumped', (WidgetTester tester) async {
       final key = GlobalKey(debugLabel: 'childKey');
@@ -40,7 +24,7 @@ void main() {
       final provider = HttpClientProvider(
         client: mockClient,
         child: Builder(builder: (context) {
-          expect(HttpClientProvider.of(context).client, same(mockClient));
+          expect(HttpClientProvider.of(context)!.client, same(mockClient));
           return Container();
         }),
       );

--- a/test/unit/screens/home_test.dart
+++ b/test/unit/screens/home_test.dart
@@ -4,11 +4,8 @@ import 'package:flutter/material.dart' hide HttpClientProvider;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' show Response;
 import 'package:http/testing.dart' show MockClient, MockClientHandler;
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart'
-    show MockPlatformInterfaceMixin;
-import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart'
-    show UrlLauncherPlatform;
 
 import 'package:noclick_me/provider/http_client_provider.dart'
     show HttpClientProvider;
@@ -20,23 +17,24 @@ import 'package:noclick_me/url_form.dart' show UrlForm;
 
 import 'package:noclick_me/screens/home.dart';
 
-class MockUrlLauncher extends Mock
-    with MockPlatformInterfaceMixin
-    implements UrlLauncherPlatform {}
+import 'home_test.mocks.dart';
 
-class MockNavigatorObserver extends Mock implements NavigatorObserver {}
-
+// TODO: remove returnNullOnMissingStub
+@GenerateMocks([], customMocks: [
+  MockSpec<NavigatorObserver>(returnNullOnMissingStub: true),
+])
 void main() {
   group('Home', () {
     final mockNavigatorObserver = MockNavigatorObserver();
 
     Widget createHomeScreen(
-            {MockClientHandler mockClientHandler,
-            FutureOr<void> Function(String url) onSuccess}) =>
+            {MockClientHandler? mockClientHandler,
+            FutureOr<void> Function(String url)? onSuccess}) =>
         MaterialApp(
           navigatorObservers: [mockNavigatorObserver],
           home: HttpClientProvider(
-            client: MockClient(mockClientHandler ?? (r) => null),
+            client:
+                MockClient(mockClientHandler ?? ((r) => Future.value(null))),
             child: screenutilBuilder(
               child: Home(),
             ),

--- a/test/unit/screens/show_test.dart
+++ b/test/unit/screens/show_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show MethodCall, SystemChannels;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'package:noclick_me/screenutil_builder.dart' show screenutilBuilder;
@@ -8,8 +9,12 @@ import 'package:noclick_me/screenutil_builder.dart' show screenutilBuilder;
 import 'package:noclick_me/net.dart' show CreateUrlResponse, RateLimitInfo;
 import 'package:noclick_me/screens/show.dart';
 
-class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+import 'show_test.mocks.dart';
 
+// TODO: remove returnNullOnMissingStub
+@GenerateMocks([], customMocks: [
+  MockSpec<NavigatorObserver>(returnNullOnMissingStub: true),
+])
 void main() {
   group('ShowUrlScreen', () {
     const mockUrl =
@@ -24,10 +29,6 @@ void main() {
     );
 
     setUp(() => reset(mockNavigatorObserver));
-
-    test('Constructor asserts on null response', () {
-      expect(() => ShowUrlScreen(null), throwsAssertionError);
-    });
 
     testWidgets('shows the URL (and only the URL if there is no rate limit',
         (WidgetTester tester) async {
@@ -61,7 +62,7 @@ void main() {
     testWidgets('COPY copies the URL to the clipboard',
         (WidgetTester tester) async {
       // Mock the clipboard service
-      var clipboardData = <String, dynamic>{
+      Map<String, dynamic>? clipboardData = <String, dynamic>{
         'text': null,
       };
       Future<dynamic> handler(MethodCall methodCall) async {
@@ -69,7 +70,7 @@ void main() {
           case 'Clipboard.getData':
             return clipboardData;
           case 'Clipboard.setData':
-            clipboardData = methodCall.arguments as Map<String, dynamic>;
+            clipboardData = methodCall.arguments as Map<String, dynamic>?;
             break;
         }
       }
@@ -83,7 +84,7 @@ void main() {
 
       await tester.tap(copyButtonFinder);
       await tester.pump();
-      expect(clipboardData['text'], mockUrl);
+      expect(clipboardData!['text'], mockUrl);
       verifyNever(mockNavigatorObserver.didPop(any, any));
     });
 

--- a/test/unit/url_form_test.dart
+++ b/test/unit/url_form_test.dart
@@ -18,12 +18,13 @@ void main() {
     const errorMsg = 'Please enter a valid http/https internet URL';
 
     Widget createForm(
-            {MockClientHandler mockClientHandler,
-            FutureOr<void> Function(CreateUrlResponse response) onSuccess}) =>
+            {MockClientHandler? mockClientHandler,
+            FutureOr<void> Function(CreateUrlResponse response)? onSuccess}) =>
         MaterialApp(
           home: Scaffold(
             body: HttpClientProvider(
-              client: MockClient(mockClientHandler ?? (r) => null),
+              client:
+                  MockClient(mockClientHandler ?? ((r) => Future.value(null))),
               child: screenutilBuilder(
                 child: UrlForm(onSuccess: onSuccess),
               ),
@@ -135,7 +136,7 @@ void main() {
       });
 
       testWidgets('server response is not 200 OK', (WidgetTester tester) async {
-        CreateUrlResponse response;
+        CreateUrlResponse? response;
         await tester.pumpWidget(createForm(
           mockClientHandler: (r) async => Response('BAD', 400),
           onSuccess: (r) => response = r,
@@ -166,7 +167,7 @@ void main() {
           (WidgetTester tester) async {
         const exceptionText = 'Unexpected!Ex';
         await tester.pumpWidget(createForm(
-          mockClientHandler: (r) async => throw Exception(exceptionText),
+          mockClientHandler: ((r) async => throw Exception(exceptionText)),
         ));
 
         await tester.enterText(
@@ -189,8 +190,7 @@ void main() {
     });
 
     group('succeeds', () {
-      void testInputSucceeds(
-          {@required String input, @required String output}) {
+      void testInputSucceeds({required String input, required String output}) {
         Future<Response> createUrlHandler(Request r) async {
           final dynamic req = jsonDecode(r.body);
           final u = Uri.parse(req['url'].toString());
@@ -199,7 +199,7 @@ void main() {
         }
 
         testWidgets('for $input', (WidgetTester tester) async {
-          CreateUrlResponse response;
+          late CreateUrlResponse response;
           await tester.pumpWidget(createForm(
             mockClientHandler: createUrlHandler,
             onSuccess: (r) => response = r,

--- a/tool/ci
+++ b/tool/ci
@@ -25,13 +25,27 @@ cmd_build_web() {
 }
 
 cmd_ci() {
+  cmd_setup
   cmd_check
   cmd_test
   cmd_cov_check
 }
 
-cmd_check() {
+cmd_setup() {
+  cmd_get_deps
+  cmd_gen_mocks
+}
+
+cmd_get_deps() {
   flutter pub get
+}
+
+cmd_gen_mocks() {
+  echo "Generating mocks..."
+  flutter pub run build_runner build
+}
+
+cmd_check() {
   cmd_format
   cmd_analyze
 }
@@ -61,17 +75,17 @@ test_normal() {
 }
 
 cmd_test_unit() {
-  echo "Running unit tests"
+  echo "Running unit tests..."
   test_normal test/unit
 }
 
 cmd_test_goldens() {
-  echo "Running goldens tests"
+  echo "Running goldens tests..."
   test_normal test/goldens
 }
 
 cmd_test_special() {
-  echo "Running special tests"
+  echo "Running special tests..."
   (
   shopt -s nullglob
   for t in test/special/*


### PR DESCRIPTION
There are a few more, technically unrelated but minimal, changes, but they are minimal and it would have been hard to make the code work without them.

There is more work to adapt things to null-safety to use it more idiomatically.

A big change needed because of this is now mockito mocks use code generation, which is quite annoying. Generated files are not added to the repo; to generate them use:

```sh
flutter pub run build_runner build
```

This is being run by the CI automatically.